### PR TITLE
perf: 用 CheckInBattle 自循环替代 Speed2x 的 40s 硬等待

### DIFF
--- a/resource/base/pipeline/pvp.json
+++ b/resource/base/pipeline/pvp.json
@@ -214,12 +214,16 @@
         ],
         "template": "pvp/in_battle.png",
         "threshold": 0.8,
-        "pre_delay": 500,
+        "pre_delay": 3000,
         "action": {
             "type": "DoNothing"
         },
+        "timeout": 300000,
         "next": [
-            "PVP.Speed2x"
+            "PVP.CheckInBattle"
+        ],
+        "on_error": [
+            "PVP.ReadResult"
         ],
         "focus": {
             "Node.Recognition.Succeeded": {
@@ -246,9 +250,8 @@
         "action": {
             "type": "Click"
         },
-        "post_delay": 40000,
         "next": [
-            "PVP.ReadResult"
+            "PVP.CheckInBattle"
         ]
     },
     "PVP.ReadResult": {
@@ -256,7 +259,7 @@
         "recognition": "Custom",
         "custom_recognition": "ReadPVPResult",
         "custom_recognition_param": "{\"result_roi\": [62,44,189,47], \"current_score_roi\": [78,264,92,40], \"score_change_roi\": [190,264,50,36], \"current_rank_roi\": [77,352,94,35], \"rank_change_roi\": [175,348,73,35]}",
-        "pre_delay": 3000,
+        "pre_delay": 5000,
         "action": {
             "type": "DoNothing"
         },


### PR DESCRIPTION
## 变更摘要 / Summary

- Speed2x: 删除 `post_delay: 40000` 硬等待，点击 2 倍速后直接进入战斗监控
- CheckInBattle: 改为自循环轮询节点（`pre_delay: 3000`，`timeout: 300000`），战斗结束时经 `on_error` 进入 ReadResult
- ReadResult: `pre_delay` 从 3000 改为 5000，给结果动画留出时间

## 验证 / Validation

- [x] `pnpm exec maa-tools check` 通过

## 影响范围 / Impact

- 仅修改 `resource/base/pipeline/pvp.json`，涉及 Speed2x、CheckInBattle、ReadResult 三个节点

## Summary by Sourcery

增强功能：
- 重新配置 PVP 流水线中的 `Speed2x`、`CheckInBattle` 和 `ReadResult` 节点，使其依赖战斗状态轮询而非硬编码等待。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Reconfigure Speed2x, CheckInBattle, and ReadResult nodes in the PVP pipeline to rely on battle state polling instead of hard-coded waiting.

</details>