### PR TITLE
ci: add mirrorchyan uploading

### DIFF
--- a/.github/workflows/mirrorchyan_release.yml
+++ b/.github/workflows/mirrorchyan_release.yml
@@ -1,0 +1,88 @@
+name: mirrorchyan_release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ""
+        required: false
+
+jobs:
+  mirrorchyan_mfaa:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'APPLe-DF' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: win
+            arch: x86_64
+            filename: "MaaKEDR-win-x86_64-*-MFAA.zip"
+          - os: win
+            arch: aarch64
+            filename: "MaaKEDR-win-aarch64-*-MFAA.zip"
+          - os: macos
+            arch: x86_64
+            filename: "MaaKEDR-macos-x86_64-*-MFAA.tar.gz"
+          - os: macos
+            arch: aarch64
+            filename: "MaaKEDR-macos-aarch64-*-MFAA.tar.gz"
+          - os: linux
+            arch: x86_64
+            filename: "MaaKEDR-linux-x86_64-*-MFAA.tar.gz"
+          - os: linux
+            arch: aarch64
+            filename: "MaaKEDR-linux-aarch64-*-MFAA.tar.gz"
+    steps:
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: ${{ matrix.filename }}
+          mirrorchyan_rid: MaaKEDR
+          tag: ${{ inputs.tag }}
+
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
+          owner: APPLe-DF
+          repo: MaaKEDR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+  mirrorchyan_mxu:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'APPLe-DF' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: win
+            arch: x86_64
+            filename: "MaaKEDR-win-x86_64-*-MXU.zip"
+          - os: win
+            arch: aarch64
+            filename: "MaaKEDR-win-aarch64-*-MXU.zip"
+          - os: macos
+            arch: x86_64
+            filename: "MaaKEDR-macos-x86_64-*-MXU.tar.gz"
+          - os: macos
+            arch: aarch64
+            filename: "MaaKEDR-macos-aarch64-*-MXU.tar.gz"
+          - os: linux
+            arch: x86_64
+            filename: "MaaKEDR-linux-x86_64-*-MXU.tar.gz"
+    steps:
+      - uses: MirrorChyan/uploading-action@v1
+        with:
+          filetype: latest-release
+          filename: ${{ matrix.filename }}
+          mirrorchyan_rid: MaaKEDR-MXU
+          tag: ${{ inputs.tag }}
+
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
+          owner: APPLe-DF
+          repo: MaaKEDR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -1,0 +1,41 @@
+name: mirrorchyan_release_note
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: ""
+        required: false
+  release:
+    types: [edited]
+
+jobs:
+  mirrorchyan_mfaa:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'APPLe-DF' }}
+    steps:
+      - id: uploading
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: MaaKEDR
+          version_name: ${{ inputs.tag }}
+
+          owner: APPLe-DF
+          repo: MaaKEDR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}
+
+  mirrorchyan_mxu:
+    runs-on: macos-latest
+    if: ${{ github.repository_owner == 'APPLe-DF' }}
+    steps:
+      - id: uploading
+        uses: MirrorChyan/release-note-action@v1
+        with:
+          mirrorchyan_rid: MaaKEDR-MXU
+          version_name: ${{ inputs.tag }}
+
+          owner: APPLe-DF
+          repo: MaaKEDR
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_token: ${{ secrets.MirrorChyanUploadToken }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,13 @@ jobs:
           files: |
             release-assets/*.zip
             release-assets/*.tar.gz
+      - name: Trigger MirrorChyanUploading
+        shell: bash
+        run: |
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release.yml -f tag=${{ github.ref_name }}
+          gh workflow run --repo $GITHUB_REPOSITORY mirrorchyan_release_note.yml -f tag=${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Dispatch post-release hooks
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
接入 Mirror酱(MirrorChyan) 第三方分发服务。

## Summary by Sourcery

将 MirrorChyan 集成为发布及发布说明的第三方分发目标。

Build:
- 添加专门的 MirrorChyan 工作流，用于上传 MaaKEDR 发布制品以及 MFAA 和 MXU 版本的发布说明。
- 将主发布工作流接入，使其使用当前标签触发 MirrorChyan 的上传和发布说明工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate MirrorChyan as a third-party distribution target for releases and release notes.

Build:
- Add dedicated MirrorChyan workflows for uploading MaaKEDR release artifacts and release notes for MFAA and MXU variants.
- Wire the main release workflow to trigger the MirrorChyan upload and release-note workflows using the current tag.

</details>