### PR TITLE
ci: 更新 GitHub Actions 版本（checkout@v7, setup-node@v7, setup-python@v7, download-artifact@v8）

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -15,9 +15,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,15 +17,15 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         if: hashFiles('pyproject.toml') != ''
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v9.0.0
         if: hashFiles('pyproject.toml') != ''
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,9 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,17 +13,17 @@ jobs:
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         if: hashFiles('pyproject.toml') != ''
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v9.0.0
         if: hashFiles('pyproject.toml') != ''
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -27,10 +27,10 @@ jobs:
       github.triggering_actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Setup oxipng

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,15 @@ jobs:
             ext: tar.gz
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         if: hashFiles('pyproject.toml') != ''
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v9.0.0
         if: hashFiles('pyproject.toml') != ''
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Generate release notes
@@ -172,7 +172,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           path: release-assets
           merge-multiple: true

--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -13,9 +13,9 @@ jobs:
     if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/maa-project.lock.json
+++ b/maa-project.lock.json
@@ -139,19 +139,19 @@
             "templateHash": "146fc4a7e29026507034652f344d0f100f70fd1a61e2a9cfa74bbabe38281b43"
         },
         ".github/workflows/format.yml": {
-            "hash": "99084caa4b24381bf13fa9129302a6ca3015cf49b1d036a90db90369d729be69",
+            "hash": "6d9f8fd2ef7747f76a2aa9c1c0571965f81db7a3b43d4b36fc33bb43f4bd0209",
             "templateHash": "88fb255e8edbbf1b9d2db38ae39406ba70855e06ff6fe1806be4fdaa1c5ba1c6"
         },
         ".github/workflows/optimize-images.yml": {
-            "hash": "73a7c9e794094326764331ef81841f10534d74e083609773d064cfbe2ce4b072",
+            "hash": "56a61521cebc62d3531b0ac1ef99321f57d40037af7e6582c14642bcdff325bc",
             "templateHash": "73a7c9e794094326764331ef81841f10534d74e083609773d064cfbe2ce4b072"
         },
         ".github/workflows/release.yml": {
-            "hash": "86fd374810ddbfdce4a19a5649a627c92d656fded88387cd356883f68124cdca",
+            "hash": "48a2055cf4d30ac6a708e91c520111a96a6e5949e0a0e439a59c5da2f2cf465e",
             "templateHash": "1948c8135358e77ebb874e0b99952b6f592f093b50efe9c4fa515786f6074172"
         },
         ".github/workflows/schema-sync.yml": {
-            "hash": "49bb37756a12155cfe4fdbdc7fd0d9a619f1b4b6f7271d12e0cf0ca7d552a261",
+            "hash": "d87ccfe91ebddd1d2df8f16d59f5c4979e58033948ce039f73a147cabc286950",
             "templateHash": "49bb37756a12155cfe4fdbdc7fd0d9a619f1b4b6f7271d12e0cf0ca7d552a261"
         },
         ".node-version": {


### PR DESCRIPTION
## 变更内容

### 更新 GitHub Actions 版本

| Action | 旧版本 | 新版本 |
|--------|--------|--------|
| actions/checkout | v6 (deploy-docs 为 v4) | v7 |
| actions/setup-python | v6 | v7 |
| actions/setup-node | v6 (deploy-docs 为 v4) | v7 |
| actions/download-artifact | v7 | v8 |
| pnpm/action-setup | v4 (仅 deploy-docs) | v6 |

### 涉及文件（7 个 workflow + 1 个 lock 文件）

- check.yml, format.yml, release.yml, check-docs.yml, deploy-docs.yml, optimize-images.yml, schema-sync.yml
- maa-project.lock.json（同步托管文件 hash）

## 检查清单
- [x] `pnpm check` 通过
- [x] schema 校验通过
- [x] MaaFW 完整性检查通过

## Summary by Sourcery

在所有 CI 流水线中更新 GitHub Actions 工作流程以使用更新的 Action 版本。

CI：
- 在所有工作流程中将 `actions/checkout` 升级到 v7。
- 在相关工作流程中将 `actions/setup-node` 升级到 v7、`actions/setup-python` 升级到 v7。
- 在发布工作流程中将 `actions/download-artifact` 更新到 v8。
- 在文档相关的工作流程中将 `pnpm/action-setup` 统一为 v6。

杂项：
- 刷新 `maa-project.lock.json` 以同步托管文件哈希值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions workflows to use newer action versions across CI pipelines.

CI:
- Bump actions/checkout to v7 in all workflows.
- Upgrade actions/setup-node to v7 and actions/setup-python to v7 in relevant workflows.
- Update actions/download-artifact to v8 in the release workflow.
- Align pnpm/action-setup to v6 in documentation-related workflows.

Chores:
- Refresh maa-project.lock.json to sync the hosted file hash.

</details>