### PR TITLE
feat(pvp): 新增赛季重置处理节点链，防止点击对战入口后卡住

### DIFF
--- a/resource/base/pipeline/pvp.json
+++ b/resource/base/pipeline/pvp.json
@@ -80,7 +80,176 @@
         },
         "post_delay": 2000,
         "next": [
+            "PVP.SeasonReset.ClickContinue",
             "PVP.CheckBattleInterface"
+        ]
+    },
+    "PVP.SeasonReset.ClickContinue": {
+        "desc": "赛季重置：识别\"点击任意处继续\"提示并点击继续（并列候选：优先排除赛季重置弹窗，未命中回落 CheckBattleInterface）",
+        "recognition": "OCR",
+        "roi": [
+            552,
+            640,
+            176,
+            31
+        ],
+        "expected": "点击任意处继续",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.SeasonReset.CheckEnterFormation",
+            "PVP.SeasonReset.ClickContinue"
+        ]
+    },
+    "PVP.SeasonReset.CheckEnterFormation": {
+        "desc": "赛季重置：识别\"进入布阵\"确认在布阵界面，不做动作",
+        "recognition": "OCR",
+        "roi": [
+            1078,
+            659,
+            97,
+            27
+        ],
+        "expected": "进入布阵",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PVP.SeasonReset.ClickEdit",
+            "PVP.SeasonReset.CheckEnterFormation"
+        ]
+    },
+    "PVP.SeasonReset.ClickEdit": {
+        "desc": "赛季重置：识别\"编辑\"并点击进入编队界面",
+        "recognition": "OCR",
+        "roi": [
+            265,
+            141,
+            54,
+            29
+        ],
+        "expected": "编辑",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.SeasonReset.ClickQuickFormation",
+            "PVP.SeasonReset.ClickEdit"
+        ]
+    },
+    "PVP.SeasonReset.ClickQuickFormation": {
+        "desc": "赛季重置：识别\"快速编队\"并点击",
+        "recognition": "OCR",
+        "roi": [
+            101,
+            441,
+            85,
+            25
+        ],
+        "expected": "快速编队",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.SeasonReset.CheckFormationCount",
+            "PVP.SeasonReset.ClickQuickFormation"
+        ]
+    },
+    "PVP.SeasonReset.CheckFormationCount": {
+        "desc": "赛季重置：识别编队人数数字出现，不做动作",
+        "recognition": "OCR",
+        "roi": [
+            203,
+            561,
+            22,
+            18
+        ],
+        "expected": "\\d",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "DoNothing"
+        },
+        "next": [
+            "PVP.SeasonReset.ClickSave",
+            "PVP.SeasonReset.CheckFormationCount"
+        ]
+    },
+    "PVP.SeasonReset.ClickSave": {
+        "desc": "赛季重置：识别\"保存\"并点击保存编队",
+        "recognition": "OCR",
+        "roi": [
+            1140,
+            442,
+            41,
+            22
+        ],
+        "expected": "保存",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.SeasonReset.ClickEnterFormation",
+            "PVP.SeasonReset.ClickSave"
+        ]
+    },
+    "PVP.SeasonReset.ClickEnterFormation": {
+        "desc": "赛季重置：识别\"进入布阵\"并点击进入布阵界面",
+        "recognition": "OCR",
+        "roi": [
+            1078,
+            659,
+            97,
+            27
+        ],
+        "expected": "进入布阵",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.SeasonReset.ClickSavePosition",
+            "PVP.SeasonReset.ClickEnterFormation"
+        ]
+    },
+    "PVP.SeasonReset.ClickSavePosition": {
+        "desc": "赛季重置：识别\"保存\"确认保存部署位置界面，点击确认",
+        "recognition": "OCR",
+        "roi": [
+            1153,
+            626,
+            49,
+            26
+        ],
+        "expected": "保存",
+        "only_rec": true,
+        "threshold": 0.8,
+        "pre_delay": 500,
+        "action": {
+            "type": "Click"
+        },
+        "next": [
+            "PVP.CheckBattleInterface",
+            "PVP.SeasonReset.ClickSavePosition"
         ]
     },
     "PVP.CheckBattleInterface": {


### PR DESCRIPTION
## 需求来源

PVP 任务在点击对战入口后，极小概率会触发**赛季重置**（出现"点击任意处继续"提示），导致流程一直卡在该界面无法进入对战。

## 变更摘要

- 新增 `PVP.SeasonReset.*` 8 节点链：识别"点击任意处继续"进入赛季重置流程，依次识别并点击「编辑 → 快速编队 → 人数数字确认 → 保存编队 → 进入布阵 → 保存部署位置」，完成后回到 `PVP.CheckBattleInterface` 正常流程
- `PVP.Entry.next` 首位挂接 `PVP.SeasonReset.ClickContinue` 作为并列候选（优先排除赛季重置弹窗）：未命中时在**同一识别轮次内**自动回落 `PVP.CheckBattleInterface`，常规路径不受影响
- 链内各节点 `next` 末尾追加**自身兜底**：点击未生效（界面文字仍在）时下一轮识别命中自身并重新点击，防止失效后卡死
- `timeout` 语义：MaaFW 中节点的 `timeout` 仅约束**本节点 `next` 列表**的识别循环（即步骤间的等待窗口），不影响上游节点的 `next` 识别；链内各步骤等待窗口统一为默认 20 秒

## 验证

```text
$ pnpm check
Checking formatting... All matched files use Prettier code style!        ✅
[OK] local project schema is valid                                      ✅
checking 3 unique resource sets with 3 jobs ... [OK] project structure looks valid ✅
$ pnpm exec maa-tools check / lint                                      ✅
```

## 涉及资源

- `resource/base/pipeline/pvp.json` — 新增 `PVP.SeasonReset.ClickContinue`、`CheckEnterFormation`、`ClickEdit`、`ClickQuickFormation`、`CheckFormationCount`、`ClickSave`、`ClickEnterFormation`、`ClickSavePosition` 共 8 个 OCR 节点，并修改 `PVP.Entry` 的 `next`

## Sourcery 总结

自动处理间歇性的 PVP 赛季重置，使进入战斗的流程能够稳定可靠地继续进行。

新功能：
- 在 PVP 进入流程中添加赛季重置处理，以便用户完成重置提示并继续进入战斗。

错误修复：
- 当出现赛季重置提示或交互未生效时，避免 PVP 流程卡住。

改进：
- 将赛季重置检测作为备用候选项，并在需要时重试每个重置步骤，从而保留正常的进入战斗路径。

测试：
- 验证格式、项目架构、资源结构以及 Maa 工具检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle intermittent PVP season resets automatically so the battle-entry workflow can continue reliably.

New Features:
- Add season-reset handling to the PVP entry flow so users can complete the reset prompts and proceed to battle.

Bug Fixes:
- Prevent the PVP workflow from becoming stuck when a season reset prompt appears or an interaction does not take effect.

Enhancements:
- Preserve the normal battle-entry path by treating season-reset detection as a fallback candidate and retrying each reset step when needed.

Tests:
- Validate formatting, project schema, resource structure, and Maa tools checks.

</details>